### PR TITLE
feature: change text inside parentheses

### DIFF
--- a/apm/package-lock.json
+++ b/apm/package-lock.json
@@ -21,7 +21,6 @@
         "node-gyp": "3.4.0",
         "npm": "6.2.0",
         "open": "0.0.5",
-        "plist": "git+https://github.com/nathansobo/node-plist.git#bd3a93387f1d4b2cff819b200870d35465796e77",
         "q": "~0.9.7",
         "read": "~1.0.5",
         "request": "^2.87.0",
@@ -3974,7 +3973,7 @@
         },
         "plist": {
           "version": "git+https://github.com/nathansobo/node-plist.git#bd3a93387f1d4b2cff819b200870d35465796e77",
-          "from": "git+https://github.com/nathansobo/node-plist.git",
+          "from": "git+https://github.com/nathansobo/node-plist.git#bd3a93387f1d4b2cff819b200870d35465796e77",
           "requires": {
             "xmlbuilder": "0.4.x",
             "xmldom": "0.1.x"

--- a/keymaps/base.cson
+++ b/keymaps/base.cson
@@ -4,6 +4,7 @@
   'end': 'editor:move-to-end-of-screen-line'
   'shift-home': 'editor:select-to-first-character-of-line'
   'shift-end': 'editor:select-to-end-of-line'
+  'ctrl-i': 'editor:change-inside-parentheses'
 
 'atom-text-editor:not([mini])':
   # Atom Specific

--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -127,6 +127,7 @@
   'ctrl-a': 'editor:move-to-first-character-of-line'
   'ctrl-e': 'editor:move-to-end-of-line'
   'ctrl-k': 'editor:cut-to-end-of-line'
+  'ctrl-i': 'editor:change-inside-parentheses'
 
   # Atom Specific
   'ctrl-shift-w': 'editor:select-word'

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -186,6 +186,7 @@
       { label: 'Select to First Character of Line', command: 'editor:select-to-first-character-of-line' }
       { label: 'Select to End of Word', command: 'editor:select-to-end-of-word' }
       { label: 'Select to End of Line', command: 'editor:select-to-end-of-line' }
+      { label: 'Select inside parentheses and delete', command: 'editor:change-inside-parentheses' }
     ]
   }
 

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -169,6 +169,7 @@
       { label: 'Select to First &Character of Line', command: 'editor:select-to-first-character-of-line' }
       { label: 'Select to End of Wor&d', command: 'editor:select-to-end-of-word' }
       { label: 'Select to End of Lin&e', command: 'editor:select-to-end-of-line' }
+      { label: 'Select inside parentheses and delete', command: 'editor:change-inside-parentheses' }
     ]
   }
 

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -168,6 +168,7 @@
       { label: 'Select to First &Character of Line', command: 'editor:select-to-first-character-of-line' }
       { label: 'Select to End of Wor&d', command: 'editor:select-to-end-of-word' }
       { label: 'Select to End of Lin&e', command: 'editor:select-to-end-of-line' }
+      { label: 'Select inside parentheses and delete', command: 'editor:change-inside-parentheses' }
     ]
   }
 

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -148,6 +148,7 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
       'editor:select-to-beginning-of-next-paragraph': -> @selectToBeginningOfNextParagraph()
       'editor:select-to-beginning-of-previous-paragraph': -> @selectToBeginningOfPreviousParagraph()
       'editor:select-to-end-of-line': -> @selectToEndOfLine()
+      'editor:change-inside-parentheses': -> @changeInsideParentheses()
       'editor:select-to-beginning-of-line': -> @selectToBeginningOfLine()
       'editor:select-to-end-of-word': -> @selectToEndOfWord()
       'editor:select-to-beginning-of-word': -> @selectToBeginningOfWord()

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -3555,7 +3555,6 @@ class TextEditor {
   changeInsideParentheses (options = {}) {
     if (!this.ensureWritable('changeInsideParentheses', options)) return
     const bufferRow = this.getCursorBufferPosition().row
-    //const leadingParentheses = new RegExp(`[(]`)
     const firstMatchIndex = this.buffer.lineForRow(bufferRow).indexOf('(')
     const secondMatchIndex = this.buffer.lineForRow(bufferRow).lastIndexOf(')')
     if (firstMatchIndex && secondMatchIndex) {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -3550,6 +3550,20 @@ class TextEditor {
   //   * `replace` Call this {Function} with a {String} to replace the match.
   backwardsScanInBufferRange (regex, range, iterator) { return this.buffer.backwardsScanInRange(regex, range, iterator) }
 
+  // Essential: Finds matching outer parentheses and deletes text inside them
+  // Moves cursor inside parentheses
+  changeInsideParentheses (options = {}) {
+    if (!this.ensureWritable('changeInsideParentheses', options)) return
+    const bufferRow = this.getCursorBufferPosition().row
+    //const leadingParentheses = new RegExp(`[(]`)
+    const firstMatchIndex = this.buffer.lineForRow(bufferRow).indexOf('(')
+    const secondMatchIndex = this.buffer.lineForRow(bufferRow).lastIndexOf(')')
+    if (firstMatchIndex && secondMatchIndex) {
+      this.setCursorBufferPosition([bufferRow, firstMatchIndex + 1])
+      this.buffer.delete([[bufferRow, firstMatchIndex + 1], [bufferRow, secondMatchIndex]])
+    }
+  }
+
   /*
   Section: Tab Behavior
   */


### PR DESCRIPTION
### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Issue or RFC Endorsed by Atom's Maintainers
404. Custom feature.

### Description of the Change
Add a new feature: With ctrl+i user can change text inside outer parentheses on the same row and jump inside parentheses. Useful for changing eg. function parentheses. In top menu user can select "Selection" and launch the feature from there.

### Alternate Designs
No alternative designs

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Testing in dev and production environment on windows and linux
Ran automated tests
Tested the feature from the menu bar as well as shortcut
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes
This feature allows users to change text inside parentheses on the same line with shortcut ctrl+i
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->